### PR TITLE
in macOS, use GNU version stat and date commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ Buffers and tabs can be renamed, and also given a custom icon.
  
 ### Installation
 
+##### Prerequisite for macOS users:
+
+Install the GNU core utilities. The implementation of the session management feature 
+internally requires GNU version `stat` and `date` commands. The built-in ones in 
+macOS are BSD version which are incomplete and not that powerful.
+
+    brew install coreutils
+
+The corresponding GNU version commands are prefixed with `g` such as `gstat` and
+`gdate`.
+
+##### Install the plugin:
+
 Use [vim-plug](https://github.com/junegunn/vim-plug) or any other Vim plugin manager.
 
 With vim-plug:

--- a/autoload/xtabline/fzf.vim
+++ b/autoload/xtabline/fzf.vim
@@ -22,8 +22,16 @@ let s:oB = { -> s:T().buffers.order     }       "ordered buffers for tab
 
 let s:sessions_path = { -> s:F.fulldir(s:Sets.sessions_path) }
 let s:use_finder    = !exists('g:loaded_fzf') || get(s:Sets, 'use_builtin_finder', 0)
-let s:lastmodified  = { f -> str2nr(system('date -r '.f.' +%s')) }
+let s:lastmodified  = { f -> str2nr(system(s:date_command.' -r '.f.' +%s')) }
 let s:obsession     = { -> exists('g:loaded_obsession') }
+
+" date and stat commands. In macOS, the corresponding ones of GNU version should be used.
+let s:date_command = 'date'
+let s:stat_command = 'stat'
+if has('mac')
+  let s:date_command = 'gdate'
+  let s:stat_command = 'gstat'
+endif
 
 " fzf/finder functions  {{{1
 
@@ -524,7 +532,7 @@ fun! s:desc_string(s, n, sfile, color) abort " {{{1
   let spaces = printf("%".spaces."s", "")
   let pad = empty(active_mark) ? '     ' : ''
   if !s:v.winOS
-    let time = system('date=`stat -c %Y '.fnameescape(a:s).'` && date -d@"$date" +%Y.%m.%d')[:-2]
+    let time = system('date=`'.s:stat_command.' -c %Y '.fnameescape(a:s).'` && '.s:date_command.' -d@"$date" +%Y.%m.%d')[:-2]
   else
     let time = ''
   endif


### PR DESCRIPTION
To solve https://github.com/mg979/vim-xtabline/issues/21, i.e., "illegal option" errors in the fzf window of session loading and deletion.